### PR TITLE
Add cache for scores

### DIFF
--- a/evolutionary_search/__init__.py
+++ b/evolutionary_search/__init__.py
@@ -291,6 +291,7 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
                                  'of samples (%i) than data (X: %i samples)'
                                  % (len(y), n_samples))
         cv = check_cv(self.cv, y, classifier=is_classifier(self.estimator))
+        cv = check_cv(self.cv, y=y, classifier=is_classifier(self.estimator))
 
         creator.create("FitnessMax", base.Fitness, weights=(1.0,))
         creator.create("Individual", list, est=clone(self.estimator), fitness=creator.FitnessMax)


### PR DESCRIPTION
Hi, This change adds a cache for scores. I noticed when optimizing 10 parameters for an xbgoost model that most scoring evaluations were duplicates. Below is output from the notebook example.
(There is another small change that is unrelated, sorry I could not find how to get github UI to create a separate pull request.)
```
cv = EvolutionaryAlgorithmSearchCV(estimator=SVC(),
                                   params=paramgrid,
                                   scoring="accuracy",
                                   cv=StratifiedKFold(y, n_folds=10),
                                   verbose=True,
                                   population_size=50,
                                   generations_number=10)
%time cv.fit(X, y)
Types [1, 2, 2] and maxint [0, 99, 99] detected
--- Evolve in 10000 possible combinations ---
Scoring evaluations: 5, Cache hits: 45, Total: 50
...
gen     nevals  avg             min             max     
0       50      0.911823        0.895028        0.983425
...
Scoring evaluations: 146, Cache hits: 3304, Total: 3450
10      24      0.981547        0.895028        0.983425
Best individual is: {'kernel': 'rbf', 'C': 53366992.312063016, 'gamma': 0.0001232846739442066}
with fitness: 0.983425414365
Scoring evaluations: 147, Cache hits: 3313, Total: 3460
CPU times: user 11.1 s, sys: 69.4 ms, total: 11.2 s
Wall time: 11.3 s
```