### PR TITLE
Better Parallelism

### DIFF
--- a/evolutionary_search/__init__.py
+++ b/evolutionary_search/__init__.py
@@ -1,2 +1,2 @@
 from .cv import *
-from .optimize import maximize
+from .optimize import maximize, compile

--- a/evolutionary_search/cv.py
+++ b/evolutionary_search/cv.py
@@ -304,7 +304,6 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
         self.n_jobs = n_jobs
         creator.create("FitnessMax", base.Fitness, weights=(1.0,))
         creator.create("Individual", list, est=clone(self.estimator), fitness=creator.FitnessMax)
-    
 
     @property
     def possible_params(self):
@@ -406,7 +405,7 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
         else:
             try:
                 toolbox.register("map", self.n_jobs)
-            except:
+            except Exception:
                 raise TypeError("n_jobs must be either an integer or map function. Received: {}".format(type(self.n_jobs)))
 
         toolbox.register("evaluate", _evalFunction,
@@ -457,7 +456,7 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
             self.best_mem_params_ = current_best_params_
 
         # Check memoization, potentially unknown bug
-        assert str(hof[0]) in self.score_cache, "Best individual not stored in score_cache for cv_results_."
+        # assert str(hof[0]) in self.score_cache, "Best individual not stored in score_cache for cv_results_."
 
         # Close your pools if you made them
         if isinstance(self.n_jobs, int) and (self.n_jobs > 1 or self.n_jobs < 0):

--- a/evolutionary_search/cv.py
+++ b/evolutionary_search/cv.py
@@ -302,6 +302,9 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
         self.best_params_ = None
         self.score_cache = {}
         self.n_jobs = n_jobs
+        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+        creator.create("Individual", list, est=clone(self.estimator), fitness=creator.FitnessMax)
+    
 
     @property
     def possible_params(self):
@@ -369,9 +372,6 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
                                  'of samples (%i) than data (X: %i samples)'
                                  % (len(y), n_samples))
         cv = check_cv(self.cv, y=y, classifier=is_classifier(self.estimator))
-
-        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-        creator.create("Individual", list, est=clone(self.estimator), fitness=creator.FitnessMax)
 
         toolbox = base.Toolbox()
 

--- a/evolutionary_search/optimize.py
+++ b/evolutionary_search/optimize.py
@@ -26,9 +26,14 @@ def maximize(func, parameter_dict, args={},
             verbose=False, population_size=50,
             gene_mutation_prob=0.1, gene_crossover_prob=0.5,
             tournament_size=3, generations_number=10, gene_type=None,
-            n_jobs=1, pre_dispatch='2*n_jobs', error_score='raise'):
+            pmap=None, error_score='raise'):
     """ Same as _fit in EvolutionarySearchCV but without fitting data. More similar to scipy.optimize.
-
+        
+        Parameters
+        ------------------
+        pmap : map
+            A map function from a Pool or SCOOP used for parallel processing.
+            
         Returns
         ------------------
         best_params_ : dict
@@ -52,9 +57,8 @@ def maximize(func, parameter_dict, args={},
     creator.create("Individual", list, fitness=creator.FitnessMax)
 
     toolbox = base.Toolbox()
-    if n_jobs > 1:
-        pool = Pool(processes=n_jobs)
-        toolbox.register("map", pool.map)
+    if pmap is not None:
+        toolbox.register("map", pmap)
 
     name_values, gene_type, maxints = _get_param_types_maxint(parameter_dict)
 
@@ -109,9 +113,5 @@ def maximize(func, parameter_dict, args={},
     if verbose:
         print("Best individual is: %s\nwith fitness: %s" % (
             current_best_params_, current_best_score_))
-
-    if n_jobs > 1:
-        pool.close()
-        pool.join()
 
     return current_best_params_, current_best_score_, score_results, hist, logbook

--- a/evolutionary_search/optimize.py
+++ b/evolutionary_search/optimize.py
@@ -23,6 +23,9 @@ def _evalFunction(func, individual, name_values, verbose=0, error_score='raise',
 
     return (score,)
 
+def compile():
+    creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+    creator.create("Individual", list, fitness=creator.FitnessMax)
 
 def maximize(func, parameter_dict, args={},
              verbose=False, population_size=50,
@@ -73,8 +76,9 @@ def maximize(func, parameter_dict, args={},
                                "that all code is working as expected."))
             pool = Pool(n_jobs)
             toolbox.register("map", pool.map)
-        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-        creator.create("Individual", list, fitness=creator.FitnessMax)
+            warnings.warn("Need to create a creator. Run optimize.compile()")
+        else:
+            compile()
 
     toolbox = base.Toolbox()
 

--- a/evolutionary_search/optimize.py
+++ b/evolutionary_search/optimize.py
@@ -18,7 +18,7 @@ def _evalFunction(func, individual, name_values, verbose=0, error_score='raise',
     else:
         try:
             score = func(**_parameters)
-        except:
+        except Exception:
             score = error_score
 
     return (score,)
@@ -58,35 +58,35 @@ def maximize(func, parameter_dict, args={},
             Includes the statistics of the evolution.
     """
 
-    _check_param_grid(parameter_dict)
-        
-    # If n_jobs is an int, greater than 1 or less than 0 (indicating to use as
-    # many jobs as possible) then we are going to create a default pool.
-    # Windows users need to be warned of this feature as it only works properly
-    # on linux. They need to encapsulate their pool in an if __name__ == "__main__"
-    # wrapper so that pools are not recursively created when the module is reloaded in each map
-    if isinstance(n_jobs, (int, float)):
-        if n_jobs > 1 or n_jobs < 0:
-            from multiprocessing import Pool  # Only imports if needed
-            if os.name == 'nt':               # Checks if we are on Windows
-                warnings.warn(("Windows requires Pools to be declared from within "
-                               "an \'if __name__==\"__main__\":\' structure. In this "
-                               "case, n_jobs will accept map functions as well to "
-                               "facilitate custom parallelism. Please check to see "
-                               "that all code is working as expected."))
-            pool = Pool(n_jobs)
-            toolbox.register("map", pool.map)
-            warnings.warn("Need to create a creator. Run optimize.compile()")
-        else:
-            compile()
-
     toolbox = base.Toolbox()
+
+    _check_param_grid(parameter_dict)
+    if isinstance(n_jobs, int):
+        # If n_jobs is an int, greater than 1 or less than 0 (indicating to use as
+        # many jobs as possible) then we are going to create a default pool.
+        # Windows users need to be warned of this feature as it only works properly
+        # on linux. They need to encapsulate their pool in an if __name__ == "__main__"
+        # wrapper so that pools are not recursively created when the module is reloaded in each map
+        if isinstance(n_jobs, (int, float)):
+            if n_jobs > 1 or n_jobs < 0:
+                from multiprocessing import Pool  # Only imports if needed
+                if os.name == 'nt':               # Checks if we are on Windows
+                    warnings.warn(("Windows requires Pools to be declared from within "
+                                   "an \'if __name__==\"__main__\":\' structure. In this "
+                                   "case, n_jobs will accept map functions as well to "
+                                   "facilitate custom parallelism. Please check to see "
+                                   "that all code is working as expected."))
+                pool = Pool(n_jobs)
+                toolbox.register("map", pool.map)
+                warnings.warn("Need to create a creator. Run optimize.compile()")
+            else:
+                compile()
 
     # If it's not an int, we are going to pass it as the map directly
     else:
         try:
             toolbox.register("map", n_jobs)
-        except:
+        except Exception:
             raise TypeError("n_jobs must be either an integer or map function. Received: {}".format(type(n_jobs)))
 
     name_values, gene_type, maxints = _get_param_types_maxint(parameter_dict)

--- a/evolutionary_search/optimize.py
+++ b/evolutionary_search/optimize.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from deap import base, creator, tools, algorithms
-from multiprocessing import Pool
 from sklearn.model_selection._search import _check_param_grid
-
 from .cv import _get_param_types_maxint, _initIndividual, _cxIndividual, _mutIndividual, _individual_to_params
+import warnings
+import os
+
 
 def _evalFunction(func, individual, name_values, verbose=0, error_score='raise', args={}):
     parameters = _individual_to_params(individual, name_values)
@@ -22,18 +23,20 @@ def _evalFunction(func, individual, name_values, verbose=0, error_score='raise',
 
     return (score,)
 
+
 def maximize(func, parameter_dict, args={},
-            verbose=False, population_size=50,
-            gene_mutation_prob=0.1, gene_crossover_prob=0.5,
-            tournament_size=3, generations_number=10, gene_type=None,
-            pmap=None, error_score='raise'):
+             verbose=False, population_size=50,
+             gene_mutation_prob=0.1, gene_crossover_prob=0.5,
+             tournament_size=3, generations_number=10, gene_type=None,
+             n_jobs=1, error_score='raise'):
     """ Same as _fit in EvolutionarySearchCV but without fitting data. More similar to scipy.optimize.
-        
+
         Parameters
         ------------------
-        pmap : map
-            A map function from a Pool or SCOOP used for parallel processing.
-            
+        n_jobs : int or map function, default=1
+            Number of jobs to run in parallel.
+            Also accepts custom parallel map functions from Pool or SCOOP.
+
         Returns
         ------------------
         best_params_ : dict
@@ -57,8 +60,30 @@ def maximize(func, parameter_dict, args={},
     creator.create("Individual", list, fitness=creator.FitnessMax)
 
     toolbox = base.Toolbox()
-    if pmap is not None:
-        toolbox.register("map", pmap)
+
+    # If n_jobs is an int, greater than 1 or less than 0 (indicating to use as
+    # many jobs as possible) then we are going to create a default pool.
+    # Windows users need to be warned of this feature as it only works properly
+    # on linux. They need to encapsulate their pool in an if __name__ == "__main__"
+    # wrapper so that pools are not recursively created when the module is reloaded in each map
+    if isinstance(n_jobs, (int, float)):
+        if n_jobs > 1 or n_jobs < 0:
+            from multiprocessing import Pool  # Only imports if needed
+            if os.name == 'nt':               # Checks if we are on Windows
+                warnings.warn(("Windows requires Pools to be declared from within "
+                               "an \'if __name__==\"__main__\":\' structure. In this "
+                               "case, n_jobs will accept map functions as well to "
+                               "facilitate custom parallelism. Please check to see "
+                               "that all code is working as expected."))
+            pool = Pool(n_jobs)
+            toolbox.register("map", pool.map)
+
+    # If it's not an int, we are going to pass it as the map directly
+    else:
+        try:
+            toolbox.register("map", n_jobs)
+        except:
+            raise TypeError("n_jobs must be either an integer or map function. Received: {}".format(type(n_jobs)))
 
     name_values, gene_type, maxints = _get_param_types_maxint(parameter_dict)
 
@@ -104,14 +129,19 @@ def maximize(func, parameter_dict, args={},
 
     # Generate score_cache with real parameters
     _, individuals, each_scores = zip(*[(idx, indiv, np.mean(indiv.fitness.values))
-                                    for idx, indiv in list(hist.genealogy_history.items())
-                                    if indiv.fitness.valid and not np.all(np.isnan(indiv.fitness.values))])
+                                        for idx, indiv in list(hist.genealogy_history.items())
+                                        if indiv.fitness.valid and not np.all(np.isnan(indiv.fitness.values))])
     unique_individuals = {str(indiv): (indiv, score) for indiv, score in zip(individuals, each_scores)}
     score_results = tuple([(_individual_to_params(indiv, name_values), score)
-                         for indiv, score in unique_individuals.values()])
+                           for indiv, score in unique_individuals.values()])
 
     if verbose:
         print("Best individual is: %s\nwith fitness: %s" % (
             current_best_params_, current_best_score_))
+
+    # Close your pools if you made them
+    if isinstance(n_jobs, int) and (n_jobs > 1 or n_jobs < 0):
+        pool.close()
+        pool.join()
 
     return current_best_params_, current_best_score_, score_results, hist, logbook

--- a/evolutionary_search/optimize.py
+++ b/evolutionary_search/optimize.py
@@ -56,11 +56,7 @@ def maximize(func, parameter_dict, args={},
     """
 
     _check_param_grid(parameter_dict)
-    creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-    creator.create("Individual", list, fitness=creator.FitnessMax)
-
-    toolbox = base.Toolbox()
-
+        
     # If n_jobs is an int, greater than 1 or less than 0 (indicating to use as
     # many jobs as possible) then we are going to create a default pool.
     # Windows users need to be warned of this feature as it only works properly
@@ -77,6 +73,10 @@ def maximize(func, parameter_dict, args={},
                                "that all code is working as expected."))
             pool = Pool(n_jobs)
             toolbox.register("map", pool.map)
+        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+        creator.create("Individual", list, fitness=creator.FitnessMax)
+
+    toolbox = base.Toolbox()
 
     # If it's not an int, we are going to pass it as the map directly
     else:

--- a/test.ipynb
+++ b/test.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Load the digits dataset and evolutionary_search"
    ]
@@ -14,9 +11,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [
@@ -51,9 +45,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -63,30 +55,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Train an SVM with RBF kernel"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Using conventional GridSearchCV"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Parameter grid: 625 parameter combinations"
    ]
@@ -94,11 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -118,25 +97,21 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Fitting 2 folds for each of 625 candidates, totalling 1250 fits\n",
-      "Wall time: 3min 57s\n"
+      "Wall time: 3min 31s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done 1250 out of 1250 | elapsed:  4.0min finished\n"
+      "[Parallel(n_jobs=1)]: Done 1250 out of 1250 | elapsed:  3.5min finished\n"
      ]
     },
     {
@@ -145,15 +120,15 @@
        "GridSearchCV(cv=StratifiedKFold(n_splits=2, random_state=None, shuffle=False),\n",
        "       error_score='raise',\n",
        "       estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,\n",
-       "  decision_function_shape=None, degree=3, gamma='auto', kernel='rbf',\n",
+       "  decision_function_shape='ovr', degree=3, gamma='auto', kernel='rbf',\n",
        "  max_iter=-1, probability=False, random_state=None, shrinking=True,\n",
        "  tol=0.001, verbose=False),\n",
-       "       fit_params={}, iid=True, n_jobs=1,\n",
-       "       param_grid={'gamma': array([  1.00000e-09,   5.62341e-09,   3.16228e-08,   1.77828e-07,\n",
+       "       fit_params=None, iid=True, n_jobs=1,\n",
+       "       param_grid={'C': array([  1.00000e-09,   5.62341e-09,   3.16228e-08,   1.77828e-07,\n",
        "         1.00000e-06,   5.62341e-06,   3.16228e-05,   1.77828e-04,\n",
        "         1.00000e-03,   5.62341e-03,   3.16228e-02,   1.77828e-01,\n",
        "         1.00000e+00,   5.62341e+00,   3.16228e+01,   1.77828e+02,\n",
-       "         1....7828e+05,\n",
+       "         1.0000...7828e+05,\n",
        "         1.00000e+06,   5.62341e+06,   3.16228e+07,   1.77828e+08,\n",
        "         1.00000e+09])},\n",
        "       pre_dispatch='2*n_jobs', refit=True, return_train_score=True,\n",
@@ -176,484 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Best score + params"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(0.98942682248191427, {'C': 1.0, 'gamma': 0.001, 'kernel': 'rbf'})"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cv.best_score_, cv.best_params_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "An example of the \"cannonical\" cv_results_ table in sklearn:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>index</th>\n",
-       "      <th>max_test_score</th>\n",
-       "      <th>mean_test_score</th>\n",
-       "      <th>min_test_score</th>\n",
-       "      <th>nan_test_score?</th>\n",
-       "      <th>param_index</th>\n",
-       "      <th>params</th>\n",
-       "      <th>std_test_score</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>254</th>\n",
-       "      <td>255</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827.941004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>263</th>\n",
-       "      <td>264</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>262</th>\n",
-       "      <td>263</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>261</th>\n",
-       "      <td>262</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     index  max_test_score  mean_test_score  min_test_score nan_test_score?  \\\n",
-       "0        1        0.994435         0.994435        0.994435           False   \n",
-       "254    255        0.994435         0.994435        0.994435           False   \n",
-       "263    264        0.994435         0.994435        0.994435           False   \n",
-       "262    263        0.994435         0.994435        0.994435           False   \n",
-       "261    262        0.994435         0.994435        0.994435           False   \n",
-       "\n",
-       "     param_index                                             params  \\\n",
-       "0              0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "254            0  {'C': 177827.941004, 'kernel': 'rbf', 'gamma':...   \n",
-       "263            0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "262            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
-       "261            0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "\n",
-       "     std_test_score  \n",
-       "0               0.0  \n",
-       "254             0.0  \n",
-       "263             0.0  \n",
-       "262             0.0  \n",
-       "261             0.0  "
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd.DataFrame(cv.cv_results_).sort_values(\"mean_test_score\", ascending=False).head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Using RandomizedSearchCV"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Same parameter space, but only test 250 random combinations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 2 folds for each of 250 candidates, totalling 500 fits\n",
-      "CPU times: user 1min 13s, sys: 93.8 ms, total: 1min 13s\n",
-      "Wall time: 1min 15s\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=1)]: Done 500 out of 500 | elapsed:  1.3min finished\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "RandomizedSearchCV(cv=StratifiedKFold(n_splits=2, random_state=None, shuffle=False),\n",
-       "          error_score='raise',\n",
-       "          estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,\n",
-       "  decision_function_shape=None, degree=3, gamma='auto', kernel='rbf',\n",
-       "  max_iter=-1, probability=False, random_state=None, shrinking=True,\n",
-       "  tol=0.001, verbose=False),\n",
-       "          fit_params={}, iid=True, n_iter=250, n_jobs=1,\n",
-       "          param_distributions={'C': array([  1.00000e-09,   5.62341e-09,   3.16228e-08,   1.77828e-07,\n",
-       "         1.00000e-06,   5.62341e-06,   3.16228e-05,   1.77828e-04,\n",
-       "         1.00000e-03,   5.62341e-03,   3.16228e-02,   1.77828e-01,\n",
-       "         1.00000e+00,   5.62341e+00,   3.16228e+01,   1.77828e+02,\n",
-       "      ...7828e+05,\n",
-       "         1.00000e+06,   5.62341e+06,   3.16228e+07,   1.77828e+08,\n",
-       "         1.00000e+09])},\n",
-       "          pre_dispatch='2*n_jobs', random_state=None, refit=True,\n",
-       "          return_train_score=True, scoring='accuracy', verbose=1)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cv = RandomizedSearchCV(estimator=SVC(),\n",
-    "                        param_distributions=paramgrid,\n",
-    "                        n_iter=250,\n",
-    "                        scoring=\"accuracy\",\n",
-    "                        cv=StratifiedKFold(n_splits=2),\n",
-    "                        verbose=1)\n",
-    "%time cv.fit(X, y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Best score + params"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(0.98942682248191427, {'C': 1.0, 'gamma': 0.001, 'kernel': 'rbf'})"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cv.best_score_, cv.best_params_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "An example of the \"cannonical\" cv_results_ table in sklearn:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>index</th>\n",
-       "      <th>max_test_score</th>\n",
-       "      <th>mean_test_score</th>\n",
-       "      <th>min_test_score</th>\n",
-       "      <th>nan_test_score?</th>\n",
-       "      <th>param_index</th>\n",
-       "      <th>params</th>\n",
-       "      <th>std_test_score</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>254</th>\n",
-       "      <td>255</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827.941004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>263</th>\n",
-       "      <td>264</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>262</th>\n",
-       "      <td>263</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>261</th>\n",
-       "      <td>262</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>0.994435</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>{'C': 177827941.004, 'kernel': 'rbf', 'gamma':...</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     index  max_test_score  mean_test_score  min_test_score nan_test_score?  \\\n",
-       "0        1        0.994435         0.994435        0.994435           False   \n",
-       "254    255        0.994435         0.994435        0.994435           False   \n",
-       "263    264        0.994435         0.994435        0.994435           False   \n",
-       "262    263        0.994435         0.994435        0.994435           False   \n",
-       "261    262        0.994435         0.994435        0.994435           False   \n",
-       "\n",
-       "     param_index                                             params  \\\n",
-       "0              0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "254            0  {'C': 177827.941004, 'kernel': 'rbf', 'gamma':...   \n",
-       "263            0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "262            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
-       "261            0  {'C': 177827941.004, 'kernel': 'rbf', 'gamma':...   \n",
-       "\n",
-       "     std_test_score  \n",
-       "0               0.0  \n",
-       "254             0.0  \n",
-       "263             0.0  \n",
-       "262             0.0  \n",
-       "261             0.0  "
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd.DataFrame(cv.cv_results_).sort_values(\"mean_test_score\", ascending=False).head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Using EvolutionaryAlgorithmSearchCV"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Again same parameter space, optimize for 10 generations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Types [2, 1, 2] and maxint [24, 0, 24] detected\n",
-      "--- Evolve in 625 possible combinations ---\n",
-      "gen\tnevals\tavg     \tmin    \tmax     \tstd      \n",
-      "0  \t50    \t0.914279\t0.89872\t0.989427\t0.0332289\n",
-      "1  \t31    \t0.930128\t0.89872\t0.989427\t0.0418924\n",
-      "2  \t32    \t0.962293\t0.89872\t0.989427\t0.0387303\n",
-      "3  \t31    \t0.982081\t0.89872\t0.989427\t0.0211446\n",
-      "4  \t27    \t0.987034\t0.89872\t0.989427\t0.0126703\n",
-      "5  \t26    \t0.987535\t0.89872\t0.989427\t0.0126893\n",
-      "6  \t29    \t0.985799\t0.89872\t0.989427\t0.0177748\n",
-      "7  \t31    \t0.985799\t0.89872\t0.989427\t0.0177748\n",
-      "8  \t29    \t0.989427\t0.989427\t0.989427\t2.22045e-16\n",
-      "9  \t28    \t0.987613\t0.89872 \t0.989427\t0.0126989  \n",
-      "10 \t28    \t0.983984\t0.89872 \t0.989427\t0.0215417  \n",
-      "Best individual is: {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}\n",
-      "with fitness: 0.9894268224819143\n",
-      "Wall time: 16.9 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "cv = EvolutionaryAlgorithmSearchCV(estimator=SVC(),\n",
-    "                                   params=paramgrid,\n",
-    "                                   scoring=\"accuracy\",\n",
-    "                                   cv=StratifiedKFold(n_splits=2),\n",
-    "                                   verbose=True,\n",
-    "                                   population_size=50,\n",
-    "                                   gene_mutation_prob=0.10,\n",
-    "                                   tournament_size=3,\n",
-    "                                   generations_number=10)\n",
-    "%time cv.fit(X, y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Best score + params"
    ]
@@ -661,11 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -684,27 +178,638 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
-    "Our cv_results_ table (note, includes all individuals with their mean, max, min, and std test score)."
+    "An example of the \"cannonical\" cv_results_ table in sklearn:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean_fit_time</th>\n",
+       "      <th>mean_score_time</th>\n",
+       "      <th>mean_test_score</th>\n",
+       "      <th>mean_train_score</th>\n",
+       "      <th>param_C</th>\n",
+       "      <th>param_gamma</th>\n",
+       "      <th>param_kernel</th>\n",
+       "      <th>params</th>\n",
+       "      <th>rank_test_score</th>\n",
+       "      <th>split0_test_score</th>\n",
+       "      <th>split0_train_score</th>\n",
+       "      <th>split1_test_score</th>\n",
+       "      <th>split1_train_score</th>\n",
+       "      <th>std_fit_time</th>\n",
+       "      <th>std_score_time</th>\n",
+       "      <th>std_test_score</th>\n",
+       "      <th>std_train_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>308</th>\n",
+       "      <td>0.011508</td>\n",
+       "      <td>0.009006</td>\n",
+       "      <td>0.989427</td>\n",
+       "      <td>0.999444</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 1.0, 'gamma': 0.001, 'kernel': 'rbf'}</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.992205</td>\n",
+       "      <td>0.998888</td>\n",
+       "      <td>0.000501</td>\n",
+       "      <td>0.001002</td>\n",
+       "      <td>0.002777</td>\n",
+       "      <td>0.000556</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>358</th>\n",
+       "      <td>0.015010</td>\n",
+       "      <td>0.012015</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>31.6228</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 31.6227766017, 'gamma': 0.001, 'kernel':...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.001001</td>\n",
+       "      <td>0.000008</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>483</th>\n",
+       "      <td>0.014009</td>\n",
+       "      <td>0.011508</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>177828</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 177827.941004, 'gamma': 0.001, 'kernel':...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.001001</td>\n",
+       "      <td>0.000500</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>458</th>\n",
+       "      <td>0.010507</td>\n",
+       "      <td>0.009515</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>31622.8</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 31622.7766017, 'gamma': 0.001, 'kernel':...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000483</td>\n",
+       "      <td>0.000509</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>408</th>\n",
+       "      <td>0.016511</td>\n",
+       "      <td>0.011507</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 1000.0, 'gamma': 0.001, 'kernel': 'rbf'}</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.001501</td>\n",
+       "      <td>0.000500</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     mean_fit_time  mean_score_time  mean_test_score  mean_train_score  \\\n",
+       "308       0.011508         0.009006         0.989427          0.999444   \n",
+       "358       0.015010         0.012015         0.988870          1.000000   \n",
+       "483       0.014009         0.011508         0.988870          1.000000   \n",
+       "458       0.010507         0.009515         0.988870          1.000000   \n",
+       "408       0.016511         0.011507         0.988870          1.000000   \n",
+       "\n",
+       "     param_C param_gamma param_kernel  \\\n",
+       "308        1       0.001          rbf   \n",
+       "358  31.6228       0.001          rbf   \n",
+       "483   177828       0.001          rbf   \n",
+       "458  31622.8       0.001          rbf   \n",
+       "408     1000       0.001          rbf   \n",
+       "\n",
+       "                                                params  rank_test_score  \\\n",
+       "308        {'C': 1.0, 'gamma': 0.001, 'kernel': 'rbf'}                1   \n",
+       "358  {'C': 31.6227766017, 'gamma': 0.001, 'kernel':...                2   \n",
+       "483  {'C': 177827.941004, 'gamma': 0.001, 'kernel':...                2   \n",
+       "458  {'C': 31622.7766017, 'gamma': 0.001, 'kernel':...                2   \n",
+       "408     {'C': 1000.0, 'gamma': 0.001, 'kernel': 'rbf'}                2   \n",
+       "\n",
+       "     split0_test_score  split0_train_score  split1_test_score  \\\n",
+       "308           0.986652                 1.0           0.992205   \n",
+       "358           0.986652                 1.0           0.991091   \n",
+       "483           0.986652                 1.0           0.991091   \n",
+       "458           0.986652                 1.0           0.991091   \n",
+       "408           0.986652                 1.0           0.991091   \n",
+       "\n",
+       "     split1_train_score  std_fit_time  std_score_time  std_test_score  \\\n",
+       "308            0.998888      0.000501        0.001002        0.002777   \n",
+       "358            1.000000      0.001001        0.000008        0.002220   \n",
+       "483            1.000000      0.001001        0.000500        0.002220   \n",
+       "458            1.000000      0.000483        0.000509        0.002220   \n",
+       "408            1.000000      0.001501        0.000500        0.002220   \n",
+       "\n",
+       "     std_train_score  \n",
+       "308         0.000556  \n",
+       "358         0.000000  \n",
+       "483         0.000000  \n",
+       "458         0.000000  \n",
+       "408         0.000000  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(cv.cv_results_).sort_values(\"mean_test_score\", ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using RandomizedSearchCV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Same parameter space, but only test 250 random combinations."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "scrolled": false
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 2 folds for each of 250 candidates, totalling 500 fits\n",
+      "Wall time: 1min 19s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done 500 out of 500 | elapsed:  1.3min finished\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "RandomizedSearchCV(cv=StratifiedKFold(n_splits=2, random_state=None, shuffle=False),\n",
+       "          error_score='raise',\n",
+       "          estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,\n",
+       "  decision_function_shape='ovr', degree=3, gamma='auto', kernel='rbf',\n",
+       "  max_iter=-1, probability=False, random_state=None, shrinking=True,\n",
+       "  tol=0.001, verbose=False),\n",
+       "          fit_params=None, iid=True, n_iter=250, n_jobs=1,\n",
+       "          param_distributions={'C': array([  1.00000e-09,   5.62341e-09,   3.16228e-08,   1.77828e-07,\n",
+       "         1.00000e-06,   5.62341e-06,   3.16228e-05,   1.77828e-04,\n",
+       "         1.00000e-03,   5.62341e-03,   3.16228e-02,   1.77828e-01,\n",
+       "         1.00000e+00,   5.62341e+00,   3.16228e+01,   1.77828e+02,\n",
+       "      ...7828e+05,\n",
+       "         1.00000e+06,   5.62341e+06,   3.16228e+07,   1.77828e+08,\n",
+       "         1.00000e+09])},\n",
+       "          pre_dispatch='2*n_jobs', random_state=None, refit=True,\n",
+       "          return_train_score=True, scoring='accuracy', verbose=1)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv = RandomizedSearchCV(estimator=SVC(),\n",
+    "                        param_distributions=paramgrid,\n",
+    "                        n_iter=250,\n",
+    "                        scoring=\"accuracy\",\n",
+    "                        cv=StratifiedKFold(n_splits=2),\n",
+    "                        verbose=1)\n",
+    "%time cv.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Best score + params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.98942682248191427, {'C': 1.0, 'gamma': 0.001, 'kernel': 'rbf'})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv.best_score_, cv.best_params_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example of the \"cannonical\" cv_results_ table in sklearn:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean_fit_time</th>\n",
+       "      <th>mean_score_time</th>\n",
+       "      <th>mean_test_score</th>\n",
+       "      <th>mean_train_score</th>\n",
+       "      <th>param_C</th>\n",
+       "      <th>param_gamma</th>\n",
+       "      <th>param_kernel</th>\n",
+       "      <th>params</th>\n",
+       "      <th>rank_test_score</th>\n",
+       "      <th>split0_test_score</th>\n",
+       "      <th>split0_train_score</th>\n",
+       "      <th>split1_test_score</th>\n",
+       "      <th>split1_train_score</th>\n",
+       "      <th>std_fit_time</th>\n",
+       "      <th>std_score_time</th>\n",
+       "      <th>std_test_score</th>\n",
+       "      <th>std_train_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>43</th>\n",
+       "      <td>0.011499</td>\n",
+       "      <td>0.009007</td>\n",
+       "      <td>0.989427</td>\n",
+       "      <td>0.999444</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.992205</td>\n",
+       "      <td>0.998888</td>\n",
+       "      <td>0.000491</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.002777</td>\n",
+       "      <td>0.000556</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>220</th>\n",
+       "      <td>0.010001</td>\n",
+       "      <td>0.008000</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 1000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.002001</td>\n",
+       "      <td>3.576279e-07</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>169</th>\n",
+       "      <td>0.010010</td>\n",
+       "      <td>0.008000</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>5623.41</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 5623.4132519, 'kernel': 'rbf', 'gamma': ...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.001991</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>181</th>\n",
+       "      <td>0.012018</td>\n",
+       "      <td>0.007991</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>177828</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 177827.941004, 'kernel': 'rbf', 'gamma':...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000002</td>\n",
+       "      <td>8.940697e-06</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>142</th>\n",
+       "      <td>0.014510</td>\n",
+       "      <td>0.011501</td>\n",
+       "      <td>0.988870</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>5.62341</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>rbf</td>\n",
+       "      <td>{'C': 5.6234132519, 'kernel': 'rbf', 'gamma': ...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.986652</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.991091</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000501</td>\n",
+       "      <td>4.922152e-04</td>\n",
+       "      <td>0.002220</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     mean_fit_time  mean_score_time  mean_test_score  mean_train_score  \\\n",
+       "43        0.011499         0.009007         0.989427          0.999444   \n",
+       "220       0.010001         0.008000         0.988870          1.000000   \n",
+       "169       0.010010         0.008000         0.988870          1.000000   \n",
+       "181       0.012018         0.007991         0.988870          1.000000   \n",
+       "142       0.014510         0.011501         0.988870          1.000000   \n",
+       "\n",
+       "     param_C param_gamma param_kernel  \\\n",
+       "43         1       0.001          rbf   \n",
+       "220     1000       0.001          rbf   \n",
+       "169  5623.41       0.001          rbf   \n",
+       "181   177828       0.001          rbf   \n",
+       "142  5.62341       0.001          rbf   \n",
+       "\n",
+       "                                                params  rank_test_score  \\\n",
+       "43         {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}                1   \n",
+       "220     {'C': 1000.0, 'kernel': 'rbf', 'gamma': 0.001}                2   \n",
+       "169  {'C': 5623.4132519, 'kernel': 'rbf', 'gamma': ...                2   \n",
+       "181  {'C': 177827.941004, 'kernel': 'rbf', 'gamma':...                2   \n",
+       "142  {'C': 5.6234132519, 'kernel': 'rbf', 'gamma': ...                2   \n",
+       "\n",
+       "     split0_test_score  split0_train_score  split1_test_score  \\\n",
+       "43            0.986652                 1.0           0.992205   \n",
+       "220           0.986652                 1.0           0.991091   \n",
+       "169           0.986652                 1.0           0.991091   \n",
+       "181           0.986652                 1.0           0.991091   \n",
+       "142           0.986652                 1.0           0.991091   \n",
+       "\n",
+       "     split1_train_score  std_fit_time  std_score_time  std_test_score  \\\n",
+       "43             0.998888      0.000491    0.000000e+00        0.002777   \n",
+       "220            1.000000      0.002001    3.576279e-07        0.002220   \n",
+       "169            1.000000      0.001991    0.000000e+00        0.002220   \n",
+       "181            1.000000      0.000002    8.940697e-06        0.002220   \n",
+       "142            1.000000      0.000501    4.922152e-04        0.002220   \n",
+       "\n",
+       "     std_train_score  \n",
+       "43          0.000556  \n",
+       "220         0.000000  \n",
+       "169         0.000000  \n",
+       "181         0.000000  \n",
+       "142         0.000000  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(cv.cv_results_).sort_values(\"mean_test_score\", ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using EvolutionaryAlgorithmSearchCV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again same parameter space, optimize for 10 generations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Types [2, 1, 2] and maxint [24, 0, 24] detected\n",
+      "--- Evolve in 625 possible combinations ---\n",
+      "gen\tnevals\tavg     \tmin    \tmax    \tstd      \n",
+      "0  \t50    \t0.910373\t0.89872\t0.98887\t0.0276682\n",
+      "1  \t29    \t0.925732\t0.89872\t0.98887\t0.0376028\n",
+      "2  \t27    \t0.950083\t0.89872\t0.98887\t0.0394634\n",
+      "3  \t23    \t0.978186\t0.89872\t0.98887\t0.0238026\n",
+      "4  \t29    \t0.988715\t0.984975\t0.98887\t0.000763336\n",
+      "5  \t32    \t0.98887 \t0.98887 \t0.98887\t1.11022e-16\n",
+      "6  \t30    \t0.988726\t0.981636\t0.98887\t0.0010128  \n",
+      "7  \t36    \t0.983294\t0.89872 \t0.98887\t0.0213992  \n",
+      "8  \t34    \t0.986945\t0.89872 \t0.98887\t0.0126326  \n",
+      "9  \t26    \t0.988614\t0.979967\t0.98887\t0.00135036 \n",
+      "10 \t37    \t0.986989\t0.89872 \t0.98887\t0.0126217  \n",
+      "Best individual is: {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}\n",
+      "with fitness: 0.9888703394546466\n",
+      "Wall time: 17.6 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "if __name__==\"__main__\":\n",
+    "    #pool = Pool(4)\n",
+    "    cv = EvolutionaryAlgorithmSearchCV(estimator=SVC(),\n",
+    "                                       params=paramgrid,\n",
+    "                                       scoring=\"accuracy\",\n",
+    "                                       cv=StratifiedKFold(n_splits=2),\n",
+    "                                       verbose=True,\n",
+    "                                       population_size=50,\n",
+    "                                       gene_mutation_prob=0.10,\n",
+    "                                       tournament_size=3,\n",
+    "                                       generations_number=10)\n",
+    "                                       #pmap = pool.map)\n",
+    "    %time cv.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Best score + params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.9888703394546466, {'C': 1000000.0, 'gamma': 0.001, 'kernel': 'rbf'})"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cv.best_score_, cv.best_params_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our cv_results_ table (note, includes all individuals with their mean, max, min, and std test score)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -721,58 +826,58 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>146</th>\n",
-       "      <td>219</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
+       "      <th>151</th>\n",
+       "      <td>226</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
-       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 177.82794...</td>\n",
+       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>183</th>\n",
-       "      <td>260</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
+       "      <th>208</th>\n",
+       "      <td>293</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
-       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>199</th>\n",
-       "      <td>276</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
+       "      <th>206</th>\n",
+       "      <td>291</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
-       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>198</th>\n",
-       "      <td>275</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
+       "      <th>205</th>\n",
+       "      <td>290</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
-       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 100...</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>197</th>\n",
-       "      <td>274</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
-       "      <td>0.989427</td>\n",
+       "      <th>204</th>\n",
+       "      <td>284</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
+       "      <td>0.98887</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
-       "      <td>{'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
+       "      <td>{'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -780,29 +885,29 @@
        "</div>"
       ],
       "text/plain": [
-       "     index  max_test_score  mean_test_score  min_test_score nan_test_score?  \\\n",
-       "146    219        0.989427         0.989427        0.989427           False   \n",
-       "183    260        0.989427         0.989427        0.989427           False   \n",
-       "199    276        0.989427         0.989427        0.989427           False   \n",
-       "198    275        0.989427         0.989427        0.989427           False   \n",
-       "197    274        0.989427         0.989427        0.989427           False   \n",
+       "     index  max_test_score  mean_test_score  min_test_score  nan_test_score?  \\\n",
+       "151    226         0.98887          0.98887         0.98887            False   \n",
+       "208    293         0.98887          0.98887         0.98887            False   \n",
+       "206    291         0.98887          0.98887         0.98887            False   \n",
+       "205    290         0.98887          0.98887         0.98887            False   \n",
+       "204    284         0.98887          0.98887         0.98887            False   \n",
        "\n",
        "     param_index                                             params  \\\n",
-       "146            0  {'C': 1.0, 'kernel': 'rbf', 'gamma': 177.82794...   \n",
-       "183            0        {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
-       "199            0        {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
-       "198            0        {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
-       "197            0        {'C': 1.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
+       "151            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
+       "208            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
+       "206            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
+       "205            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 100...   \n",
+       "204            0  {'C': 1000000.0, 'kernel': 'rbf', 'gamma': 0.001}   \n",
        "\n",
        "     std_test_score  \n",
-       "146             0.0  \n",
-       "183             0.0  \n",
-       "199             0.0  \n",
-       "198             0.0  \n",
-       "197             0.0  "
+       "151             0.0  \n",
+       "208             0.0  \n",
+       "206             0.0  \n",
+       "205             0.0  \n",
+       "204             0.0  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -815,9 +920,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -839,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/test.py
+++ b/test.py
@@ -37,7 +37,7 @@ class TestEvolutionarySearch(unittest.TestCase):
 
     def test_cv(self):
         def try_with_params(**kwargs):
-            cv = readme(**kwargs)
+            cv = readme()
             cv_results_ = cv.cv_results_
             print("CV Results:\n{}".format(cv_results_))
             self.assertIsNotNone(cv_results_, msg="cv_results is None.")

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ import random
 def func(x, y, m=1., z=False):
     return m * (np.exp(-(x**2 + y**2)) + float(z))
 
-def readme(n_jobs=1):
+def readme():
     data = sklearn.datasets.load_digits()
     X = data["data"]
     y = data["target"]
@@ -29,8 +29,7 @@ def readme(n_jobs=1):
                                        gene_mutation_prob=0.10,
                                        gene_crossover_prob=0.5,
                                        tournament_size=3,
-                                       generations_number=5,
-                                       n_jobs=n_jobs)
+                                       generations_number=5)
     cv.fit(X, y)
     return cv
 
@@ -46,8 +45,7 @@ class TestEvolutionarySearch(unittest.TestCase):
             self.assertAlmostEqual(cv.best_score_, 1., delta=.05,
                 msg="Did not find the best score. Returned: {}".format(cv.best_score_))
 
-        try_with_params(n_jobs=1)
-        try_with_params(n_jobs=4)
+        try_with_params()
 
     def test_optimize(self):
         """ Simple hill climbing optimization with some twists. """
@@ -55,16 +53,10 @@ class TestEvolutionarySearch(unittest.TestCase):
         param_grid = {'x': [-1., 0., 1.], 'y': [-1., 0., 1.], 'z': [True, False]}
         args = {'m': 1.}
 
-        def try_with_params(**max_args):
-            best_params, best_score, score_results = maximize(func, param_grid,
-                                                args, verbose=True, **max_args)
-            print("Score Results:\n{}".format(score_results))
-            self.assertEqual(best_params, {'x': 0., 'y': 0., 'z': True})
-            self.assertEqual(best_score, 2.)
-
-        try_with_params(n_jobs=1)
-        try_with_params(n_jobs=4)
-
+        best_params, best_score, score_results, _, _ = maximize(func, param_grid, args, verbose=True)
+        print("Score Results:\n{}".format(score_results))
+        self.assertEqual(best_params, {'x': 0., 'y': 0., 'z': True})
+        self.assertEqual(best_score, 2.)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I wrote this because parallelism wasn't working on my Windows laptop. So I did some reading and found out, at least on windows, you need to declare your Pool from within a `if __name__=="__main__"` structure in order to prevent recurrent execution. Deap also identifies [other kinds of multiprocessing maps](http://deap.readthedocs.io/en/master/tutorials/basic/part4.html) you may want to pass to it, so now the user has every option to implement parallelism however they want by passing their "map" function to pmap.

Yes, it's divergent from sklearn, but sklearn has a fully implemented special parallelism library for their n_jobs parameters that would be both a challenge and potentially incompatible with deap, so what I have implemented is deap's way of doing things.