### PR TITLE
added pre_dispatch kwarg

### DIFF
--- a/evolutionary_search/cv.py
+++ b/evolutionary_search/cv.py
@@ -289,7 +289,7 @@ class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
                  refit=True, verbose=False, population_size=50,
                  gene_mutation_prob=0.1, gene_crossover_prob=0.5,
                  tournament_size=3, generations_number=10, gene_type=None,
-                 n_jobs=1, iid=True, error_score='raise',
+                 n_jobs=1, iid=True, error_score='raise', pre_dispatch=None,
                  fit_params={}):
         super(EvolutionaryAlgorithmSearchCV, self).__init__(
             estimator=estimator, scoring=scoring,


### PR DESCRIPTION
The docstring states:

```
    pre_dispatch : int, or string, optional
        Dummy parameter for compatibility with sklearn's GridSearch
```

However the parameter is not included in `__init__`, breaking compatiblity with sklearn's GridSearch.

Added `pre_dispatch=None` to `__init__` in order to fix it.